### PR TITLE
Update ASTParser generated by ANTLR4.

### DIFF
--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation('org.apache.calcite:calcite-core:1.36.0')
     implementation('org.apache.calcite.avatica:avatica-core:1.23.0')
     implementation('org.apache.calcite:calcite-babel:1.34.0')
+    compileOnly('org.projectlombok:lombok:1.18.26')
+    annotationProcessor('org.projectlombok:lombok:1.18.26')
 }
 
 def mysqlDir = "src/main/java/sqlsolver/sql/mysql/internal"

--- a/sql/src/main/java/module-info.java
+++ b/sql/src/main/java/module-info.java
@@ -22,4 +22,5 @@ module sqlsolver.sql {
   requires calcite.core;
   requires avatica.core;
   requires calcite.babel;
+  requires lombok;
 }

--- a/sql/src/main/java/sqlsolver/sql/RefreshableParserInitializer.java
+++ b/sql/src/main/java/sqlsolver/sql/RefreshableParserInitializer.java
@@ -1,0 +1,117 @@
+package sqlsolver.sql;
+
+/**
+ * fix antlr memory leak
+ * @see <a href="https://github.com/antlr/antlr4/issues/499"> Memory Leak </a>
+ * @author victorchu
+ * @date 2022/8/8 11:29
+ */
+import lombok.SneakyThrows;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.dfa.DFA;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class RefreshableParserInitializer<L extends Lexer,P extends Parser> implements BiConsumer<L , P > {
+    private final AtomicReference<ParserAndLexerATNCaches<L,P>> caches = new AtomicReference<>();
+
+    public RefreshableParserInitializer() {
+        Type superClass = this.getClass().getGenericSuperclass();
+        lexer = (Class<?>)((ParameterizedType)superClass).getActualTypeArguments()[0];
+        parser = (Class<?>)((ParameterizedType)superClass).getActualTypeArguments()[1];
+        refresh();
+    }
+
+    public void refresh() {
+        caches.set(buildATNCache());
+    }
+
+    // ================= 泛型处理 =====================
+    private final Class<?> lexer;
+    private final Class<?> parser;
+
+    @SneakyThrows({SecurityException.class, NoSuchFieldException.class,IllegalAccessException.class})
+    private static ATN getATNField(Class<?> clazz){
+        Field field = clazz.getDeclaredField("_ATN");
+        field.setAccessible(true);
+        return (ATN) field.get(null);
+
+    }
+
+    private ParserAndLexerATNCaches<L,P> buildATNCache(){
+        ATN lexerATN =getATNField(lexer);
+        ATN parserATN = getATNField(parser);
+        return new ParserAndLexerATNCaches(new AntlrATNCacheFields(lexerATN),new AntlrATNCacheFields(parserATN));
+    }
+    // ================= 泛型处理 =====================
+
+    @Override
+    public void accept(L l, P p) {
+        ParserAndLexerATNCaches<L,P> cache =caches.get();
+        cache.lexer.configureLexer(l);
+        cache.parser.configureParser(p);
+    }
+
+    private static final class ParserAndLexerATNCaches<L extends Lexer,P extends Parser>
+    {
+        public ParserAndLexerATNCaches(AntlrATNCacheFields lexer, AntlrATNCacheFields parser) {
+            this.lexer = lexer;
+            this.parser = parser;
+        }
+
+        public final AntlrATNCacheFields lexer;
+        public final AntlrATNCacheFields parser;
+    }
+    public static final class AntlrATNCacheFields
+    {
+        private final ATN atn;
+        private final PredictionContextCache predictionContextCache;
+        private final DFA[] decisionToDFA;
+
+        public AntlrATNCacheFields(ATN atn)
+        {
+            this.atn = requireNonNull(atn, "atn is null");
+            this.predictionContextCache = new PredictionContextCache();
+            this.decisionToDFA = createDecisionToDFA(atn);
+        }
+
+        @SuppressWarnings("ObjectEquality")
+        public void configureLexer(Lexer lexer)
+        {
+            requireNonNull(lexer, "lexer is null");
+            // Intentional identity equals comparison
+            checkArgument(atn == lexer.getATN(), "Lexer ATN mismatch: expected %s, found %s", atn, lexer.getATN());
+            lexer.setInterpreter(new LexerATNSimulator(lexer, atn, decisionToDFA, predictionContextCache));
+        }
+
+        @SuppressWarnings("ObjectEquality")
+        public void configureParser(Parser parser)
+        {
+            requireNonNull(parser, "parser is null");
+            // Intentional identity equals comparison
+            checkArgument(atn == parser.getATN(), "Parser ATN mismatch: expected %s, found %s", atn, parser.getATN());
+            parser.setInterpreter(new ParserATNSimulator(parser, atn, decisionToDFA, predictionContextCache));
+        }
+
+        private static DFA[] createDecisionToDFA(ATN atn)
+        {
+            DFA[] decisionToDFA = new DFA[atn.getNumberOfDecisions()];
+            for (int i = 0; i < decisionToDFA.length; i++) {
+                decisionToDFA[i] = new DFA(atn.getDecisionState(i), i);
+            }
+            return decisionToDFA;
+        }
+    }
+}

--- a/sql/src/main/java/sqlsolver/sql/mysql/MySQLAstParser.java
+++ b/sql/src/main/java/sqlsolver/sql/mysql/MySQLAstParser.java
@@ -12,6 +12,8 @@ import sqlsolver.sql.ast.SqlNode;
 
 import java.util.Properties;
 import java.util.function.Function;
+import java.util.function.BiConsumer;
+import sqlsolver.sql.RefreshableParserInitializer;
 
 public class MySQLAstParser implements AstParser {
   private long serverVersion = 0;
@@ -40,6 +42,11 @@ public class MySQLAstParser implements AstParser {
     lexer.addErrorListener(ThrowingErrorListener.instance());
     parser.removeErrorListeners();
     parser.addErrorListener(ThrowingErrorListener.instance());
+
+    // 注意，此处需要构造一个匿名类
+    BiConsumer<MySQLLexer, MySQLParser> initializer = new RefreshableParserInitializer<MySQLLexer, MySQLParser>(){};
+    // refresh lexer和parser
+    initializer.accept(lexer, parser);
 
     return rule.apply(parser).accept(new MySQLAstBuilder());
   }

--- a/sql/src/main/java/sqlsolver/sql/pg/PgAstParser.java
+++ b/sql/src/main/java/sqlsolver/sql/pg/PgAstParser.java
@@ -11,6 +11,8 @@ import sqlsolver.sql.pg.internal.PGParser;
 import sqlsolver.sql.ast.SqlNode;
 
 import java.util.function.Function;
+import java.util.function.BiConsumer;
+import sqlsolver.sql.RefreshableParserInitializer;
 
 public class PgAstParser implements AstParser {
   public SqlNode parse(String str, Function<PGParser, ParserRuleContext> rule) {
@@ -21,6 +23,11 @@ public class PgAstParser implements AstParser {
     lexer.addErrorListener(ThrowingErrorListener.instance());
     parser.removeErrorListeners();
     parser.addErrorListener(ThrowingErrorListener.instance());
+
+    // 注意，此处需要构造一个匿名类
+    BiConsumer<PGLexer, PGParser> initializer = new RefreshableParserInitializer<PGLexer, PGParser>(){};
+// refresh lexer和parser
+    initializer.accept(lexer, parser);
 
     //    lexer.getInterpreter().clearDFA();
     //    parser.getInterpreter().clearDFA();


### PR DESCRIPTION
ANTLR4 in SQLSolver has a memory leak issue, causing crashes during continuous parsing of SQL statements. To address this, a refresh mechanism has been added to ```MySQLASTParser.java``` and ```PgASTParser.java```, which can resolve this problem.